### PR TITLE
 Add indexing for 'country' field b71b8ed 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ misc/tools/export s3.txt
 ansible/hosts
 
 etc/ews/peba.cfg
+
+analysis/daystats.json

--- a/Indexing.md
+++ b/Indexing.md
@@ -67,7 +67,7 @@ Fields are shown in descending alphabetical order
 Similar to the alert index (see above), only exception is the `rawhttp`-field which is missing here
 
 ### Packet Index 
-#### Name: `packets`
+#### Name: `payloads`
 ```json
 {
 	"createTime" :			"date,no",
@@ -78,7 +78,7 @@ Similar to the alert index (see above), only exception is the `rawhttp`-field wh
 	"hashfuzzyhttp" :		"keyword,no",
 	"initalDestPort" :		"keyword,no",
 	"initialIP" :			"ip,no",
-	"lastSeen" :			"date,no",
+	"lastSeen" :			"date,yes",
 	"md5count" :			"keyword,no"
 }
 ``` 

--- a/Indexing.md
+++ b/Indexing.md
@@ -31,7 +31,7 @@ Fields are shown in descending alphabetical order
 	"client" :			"keyword,no",
 	"clientDomain" :		"bool,yes",
 	"clientVersion" :		"keyword,no",
-	"country" :			"keyword,no",
+	"country" :			"keyword,yes",
 	"countryName" :			"keyword,yes",
 	"createTime" :			"date,yes",
 	"externalIP" :			"ip,no",

--- a/ansible/roles/peba-masternode/templates/rollindex_cron.sh
+++ b/ansible/roles/peba-masternode/templates/rollindex_cron.sh
@@ -33,7 +33,7 @@ curl -XPOST {{ ELASTIC_IP }}:{{ ELASTIC_PORT }}/{{ ELASTIC_INDEX }}'/_rollover?p
             },
             "country":{
                "type":"keyword",
-               "index":"false"
+               "index":"true"
             },
             "countryName":{
                "type":"keyword",

--- a/ansible/roles/peba-masternode/templates/setup-es-indices.py
+++ b/ansible/roles/peba-masternode/templates/setup-es-indices.py
@@ -349,7 +349,7 @@ index_body_packets = {
                 "createTime" : {
                     "type" : "date",
                     "format" : "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
-                    "index" : "false"
+                    "index" : "true"
                 },
                 "data" : {
                     "type" : "keyword",

--- a/ansible/roles/peba-masternode/templates/setup-es-indices.py
+++ b/ansible/roles/peba-masternode/templates/setup-es-indices.py
@@ -57,7 +57,7 @@ index_body_alerts = {
                 },
                 "country" : {
                     "type" : "keyword",
-                    "index" : "false"
+                    "index" : "true"
                 },
                 "countryName" : {
                     "type" : "keyword",

--- a/ansible/roles/peba-masternode/templates/setup-es-indices.py
+++ b/ansible/roles/peba-masternode/templates/setup-es-indices.py
@@ -382,7 +382,7 @@ index_body_packets = {
                 "lastSeen" : {
                     "type" : "date",
                     "format" : "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
-                    "index" : "false"
+                    "index" : "true"
                 },
                 "md5count" : {
                     "type" : "keyword",

--- a/ansible/roles/peba-masternode/templates/setup-es-indices.py
+++ b/ansible/roles/peba-masternode/templates/setup-es-indices.py
@@ -8,8 +8,8 @@ host = "{{ ELASTIC_IP }}"
 port = {{ ELASTIC_PORT }}
 index_alias_alert = "{{ ELASTIC_INDEX }}"
 index_name_cve = "ewscve"
-index_name_packets = "packets"
-index_name_notifications = "ews-notifications"
+index_name_packets = "payloads"
+index_name_notifications = "notifications"
 
 
 ###

--- a/misc/cron/rollindex_cron.sh
+++ b/misc/cron/rollindex_cron.sh
@@ -54,7 +54,7 @@ curl -XPOST $host:$port/$ews_alias'/_rollover?pretty' -H 'Content-Type: applicat
             },
             "country":{
                "type":"keyword",
-               "index":"false"
+               "index":"true"
             },
             "countryName":{
                "type":"keyword",

--- a/misc/setup-es-indices.py
+++ b/misc/setup-es-indices.py
@@ -355,7 +355,7 @@ index_body_packets = {
                 "createTime" : {
                     "type" : "date",
                     "format" : "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
-                    "index" : "false"
+                    "index" : "true"
                 },
                 "data" : {
                     "type" : "keyword",

--- a/misc/setup-es-indices.py
+++ b/misc/setup-es-indices.py
@@ -388,7 +388,7 @@ index_body_packets = {
                 "lastSeen" : {
                     "type" : "date",
                     "format" : "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
-                    "index" : "false"
+                    "index" : "true"
                 },
                 "md5count" : {
                     "type" : "keyword",

--- a/misc/setup-es-indices.py
+++ b/misc/setup-es-indices.py
@@ -64,7 +64,7 @@ index_body_alerts = {
                 },
                 "country" : {
                     "type" : "keyword",
-                    "index" : "false"
+                    "index" : "true"
                 },
                 "countryName" : {
                     "type" : "keyword",

--- a/misc/setup-es-indices.py
+++ b/misc/setup-es-indices.py
@@ -19,7 +19,7 @@ port = 9200
 index_alias_alert= "ews2017.1"
 index_name_cve= "ewscve"
 index_name_packets = "payloads"
-index_name_notifications = "ews-notifications"
+index_name_notifications = "notifications"
 
 es = Elasticsearch([{'host': host, 'port': 9200}])
 

--- a/misc/setupES6Indices.sh
+++ b/misc/setupES6Indices.sh
@@ -5,8 +5,8 @@ port=9200
 
 indexAlertsAlias="ews2017.1"
 indexCve="ewscve"
-indexPackets="packets"
-indexNotifications="ews-notifications"
+indexPackets="payloads"
+indexNotifications="notifications"
 
 
 #


### PR DESCRIPTION
Necessary changes to index the 'country' field in the 'alerts' type / index.

Also including direct commits from master branch which was ahead. 

@vorband - are we still maintaining the `setupES6Indices.sh` bash script? It's not included in the ansible master role, neither up to date. Should I include all the changes from `setup-es-indices.py`?

Inside the [peba-masternode role](https://github.com/dtag-dev-sec/PEBA/tree/master/ansible/roles/peba-masternode), can we fetch `setup-ex-indices.py` and `rollindex_cron.sh` using `get_url` module from this git repository instead of copying them via template local? We don't need to edit these files twice then. 

Maybe we could also define master mapping which is included in `rollindex_cron.sh` and `setup-es-indices.py`, then I'd be perfect, only one index definition. 