### PR TITLE
Use variable for "payloads"-Indexname

### DIFF
--- a/elastic.py
+++ b/elastic.py
@@ -192,11 +192,11 @@ def handlePacketData(packetdata, id, createTime, debug, es, sourceip, destport, 
             app.logger.debug("Could not determine MIME for payload %s." % packetHash)
 
     # check if packet is existing in index via hash
-    statusContent, packetContent = packetExisting(packetHash, "payloads", es, debug, "hash")
+    statusContent, packetContent = packetExisting(packetHash, payloadsIndex, es, debug, "hash")
 
     # check if packet is existing in index via fuzzyhash
     fuzzyHash=getFuzzyHash(packetdata, packetHash)
-    statusFuzzy, fuzzyHashContent = packetExisting(fuzzyHash, "payloads", es, debug, "hashfuzzyhttp")
+    statusFuzzy, fuzzyHashContent = packetExisting(fuzzyHash, payloadsIndex, es, debug, "hashfuzzyhttp")
 
     if not(statusContent or statusFuzzy):
         app.logger.debug("Unable to work with ES (handlePacketData)")
@@ -291,7 +291,7 @@ def handlePacketData(packetdata, id, createTime, debug, es, sourceip, destport, 
     try:
         app.logger.debug("Storing/Updating packet in index packets (handlePacketData)")
 
-        res = es.index(index="payloads", doc_type="Packet", id=id, body=packet, refresh=True)
+        res = es.index(index=payloadsIndex, doc_type="Packet", id=id, body=packet, refresh=True)
         return True
 
     except:

--- a/peba.py
+++ b/peba.py
@@ -58,6 +58,7 @@ if app.config['USES3']:
     )
 
 statisticIndex="statistics"
+payloadsIndex="payloads"
 
 ###############
 ### Functions


### PR DESCRIPTION
This is just a temporary fix. Long-term, this needs to be extracted
from peba.cfg and consistently changed for all index names.